### PR TITLE
Fix `Build Warning: Layout 'nil' requested in tags/.../atom.xml does not exist.`

### DIFF
--- a/source/_includes/custom/tag_feed.xml
+++ b/source/_includes/custom/tag_feed.xml
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">


### PR DESCRIPTION
PROBLEM

Running:

```
$ rake generate
```

the plugins warns, for each tag declared in posts, with the following message:

```
## Generating Site with Jekyll
    write source/stylesheets/screen.css
Configuration file: ... /octopress/_config.yml
            Source: source
       Destination: public
      Generating...
     Build Warning: Layout 'nil' requested in tags/foo_tag/atom.xml does not exist.
     Build Warning: Layout 'nil' requested in tags/bar_tag/atom.xml does not exist.
     ...
```

The rss works fine so the warning is only an annoying useless one.

CAUSE

The `layout` is configured with `nil`

SOLUTION

Configure `layout` with `null`.

robbyedwards/octopress-tag-pages#6
